### PR TITLE
Add autocompletion support for ncm-ncd.

### DIFF
--- a/src/main/config/bash_completion.d/ncm-ncd.sh
+++ b/src/main/config/bash_completion.d/ncm-ncd.sh
@@ -35,3 +35,6 @@ _ncm_ncd()
 }
 
 complete -F _ncm_ncd ncm-ncd
+complete -F _ncm_ncd quattor-configure
+complete -F _ncm_ncd quattor-list
+complete -F _ncm-ncd quattor-unconfigure


### PR DESCRIPTION
For now, it autocompletes component names and the most usual options.
No esoteric stuff for now.
