### PR TITLE
keys() on EL5/6 needs a hash, not only a hashref 

### DIFF
--- a/src/main/scripts/ncm-ncd
+++ b/src/main/scripts/ncm-ncd
@@ -483,8 +483,8 @@ if ($this_app->option('unconfigure')) {
     $msg    = 'configure';
 }
 
-# remove dulpicates and sort
-my @component_names = sort(keys(map {$_ => 1} @ARGV));
+# remove duplicates and sort
+my @component_names = sort(keys( %{ {map {$_ => 1} @ARGV} } ));
 $this_app->verbose("Sorted unique components ", join(',', @component_names), 
                    " from commandline ", join(',', @ARGV));
 


### PR DESCRIPTION
(and certainly not a hash iterator)
fixes #39 