### PR TITLE
Support ignoring failing dependencies (or dependencies altogether)

### DIFF
--- a/src/main/perl/ComponentProxy.pm
+++ b/src/main/perl/ComponentProxy.pm
@@ -336,7 +336,7 @@ sub _setDependencies {
             push (@{$self->{'PRE_DEPS'}},$el->getStringValue());
         }
         $self->debug(2, "pre dependencies for component $self->{'NAME'}: ",
-                     ' '.join(',',@{$self->{PRE_DEPS}}));
+                     join(',',@{$self->{PRE_DEPS}}));
     } else {
         $ec->ignore_error();
         $self->debug(1, "no pre dependencies found for $self->{NAME}");
@@ -349,7 +349,7 @@ sub _setDependencies {
             push (@{$self->{'POST_DEPS'}},$el->getStringValue());
         }
         $self->debug(2, "post dependencies for component $self->{NAME}: ",
-                     ' '.join(',',@{$self->{POST_DEPS}}));
+                     join(',',@{$self->{POST_DEPS}}));
     } else {
         $ec->ignore_error();
         $self->debug(1, "no post dependencies found for $self->{NAME}");

--- a/src/main/perl/ComponentProxy.pm
+++ b/src/main/perl/ComponentProxy.pm
@@ -7,6 +7,7 @@
 package NCD::ComponentProxy;
 
 use strict;
+use warnings;
 use LC::Exception qw (SUCCESS throw_error);
 
 use parent qw(CAF::ReporterMany CAF::Object);

--- a/src/main/perl/ComponentProxyList.pm
+++ b/src/main/perl/ComponentProxyList.pm
@@ -425,7 +425,7 @@ sub _sortComponents
     }
 
     # $sorted can contain components from the dependency resolution in $after
-    # that have no proxy (due to e.g. autodeps=0)
+    # that have no proxy (due to e.g. --no-autodeps)
     my @sortedcompProxyList = grep {defined($_)} map {$comps{$_}} @$sorted;
     return \@sortedcompProxyList;
 }

--- a/src/main/perl/ComponentProxyList.pm
+++ b/src/main/perl/ComponentProxyList.pm
@@ -124,9 +124,9 @@ sub run_all_components
 
     my (%failed_components);
 
-    # nodeps should be implied by the nodepsnoerrors option
+    # nodeps should be implied by the ignore-errors-from-dependencies option
     # allow it here explicitly as part of the API
-    my $downgrade_dep_errors_global = $nodeps && $this_app->option('nodepsnoerrors');
+    my $downgrade_dep_errors_global = $nodeps && $this_app->option('ignore-errors-from-dependencies');
 
     foreach my $comp (@{$components}) {
         $self->report();
@@ -148,7 +148,7 @@ sub run_all_components
             if $downgrade_dep_errors;
 
         # TODO should we remove the requested components?
-        #     a failing requested component is not a the same as a failing dependency
+        #     a failing requested component is not the same as a failing dependency
         #     (even if the requested component is a dependency of
         #      some other (requested or not) component)
         #

--- a/src/main/perl/ComponentProxyList.pm
+++ b/src/main/perl/ComponentProxyList.pm
@@ -553,6 +553,12 @@ sub skip_components
     return %to_skip;
 }
 
+# Given hashref C<comps> with components (active or inactive),
+# return the list of pre- and/or post-dependencies for
+# proxy instance C<proxy> not part of C<comps>
+# if autodeps option is set. If the autodeps option is false, either
+# log the missing component with nodeps option set
+# or log a warning and return undef with nodeps also false.
 sub missing_deps
 {
     my ($self, $proxy, $comps) = @_;

--- a/src/main/perl/ComponentProxyList.pm
+++ b/src/main/perl/ComponentProxyList.pm
@@ -333,15 +333,17 @@ sub set_state
     if ($file) {
         $self->verbose("set_state for component $comp $file (msg $msg)");
         my $fh = CAF::FileWriter->new($file, log => $self);
+        print $fh "$msg\n";
+        # calling close here will not update timestamp in case of same state
+        # so the timestamp will be of first failure with this message, not the last
+        # TODO: ok or not?
+        my $changed = $fh->close() ? "" : "not";
+
         my $err = $ec->error();
         if(defined($err)) {
+            $ec->ignore_error();
             $self->warn("failed to write state for component $comp file $file: ".$err->reason());
         } else {
-            print $fh "$msg\n";
-            # calling close here will not update timestamp in case of same state
-            # so the timestamp will be of first failure with this message, not the last
-            # TODO: ok or not?
-            my $changed = $fh->close() ? "" : "not";
             $self->verbose("state for component $comp $file $changed changed.");
         }
     } else {

--- a/src/main/scripts/ncm-ncd
+++ b/src/main/scripts/ncm-ncd
@@ -174,8 +174,8 @@ sub app_options()
         },
 
         {
-            NAME    => 'nodepsnoerrors',
-            HELP    => 'errors from broken (pre/post) dependencies in configure are downgraded to warnings (implies --nodeps --autodeps). Use with care.',
+            NAME    => 'ignore-errors-from-dependencies',
+            HELP    => 'errors from failing (pre/post) dependencies in configure are downgraded to warnings (implies --nodeps --autodeps). Use with care.',
             DEFAULT => undef
         },
 
@@ -465,8 +465,8 @@ unless ($this_app->option("ignorelock")) {
     $this_app->lock() or $this_app->finish(-1);
 }
 
-# nodepsnoerrors implies nodeps and autodeps
-if($this_app->option('nodepsnoerrors')) {
+# ignore-errors-from-dependencies implies nodeps and autodeps
+if($this_app->option('ignore-errors-from-dependencies')) {
     $this_app->{CONFIG}->set('nodeps', 1);
     $this_app->{CONFIG}->set('autodeps', 1);
 }

--- a/src/main/scripts/ncm-ncd
+++ b/src/main/scripts/ncm-ncd
@@ -31,6 +31,12 @@ sub app_options()
         @array,
 
         {
+            NAME    => 'list',
+            HELP    => 'list existing components and exit',
+            DEFAULT => undef
+        },
+
+        {
             NAME    => 'configure',
             HELP    => 'run the configure method on the components',
             DEFAULT => undef
@@ -44,7 +50,7 @@ sub app_options()
 
         {
             NAME    => 'unconfigure',
-            HELP    => 'run the unconfigure method on the component',
+            HELP    => 'run the unconfigure method on the component (only one component at a time supported)',
             DEFAULT => undef
         },
 
@@ -97,54 +103,14 @@ sub app_options()
         },
 
         {
-            NAME => 'ignorelock',
-            HELP => 'ignore application lock. Use with care.'
-        },
-
-        {
-            NAME => 'forcelock',
-            HELP => 'take over application lock. Use with care.'
-        },
-
-        {
             NAME    => 'useprofile:s',
             HELP    => 'profile to use as configuration profile (optional, otherwise latest)',
             DEFAULT => undef
         },
 
         {
-            NAME    => 'nodeps',
-            HELP    => 'ignore broken (pre/post) dependencies in configure',
-            DEFAULT => undef
-        },
-
-        {
-            NAME    => 'nodepsnoerrors',
-            HELP    => 'errors from broken (pre/post) dependencies in configure are downgraded to warnings (implies --nodeps)',
-            DEFAULT => undef
-        },
-
-        {
             NAME    => 'skip:s',
             HELP    => 'skip one component (only to be used with --all)',
-            DEFAULT => undef
-        },
-
-        {
-            NAME    => 'autodeps!',
-            HELP    => 'expand missing pre/post dependencies in configure',
-            DEFAULT => 1
-        },
-
-        {
-            NAME    => 'allowbrokencomps',
-            HELP    => 'Do not stop overall execution if broken components are found',
-            DEFAULT => 1
-        },
-
-        {
-            NAME    => 'list',
-            HELP    => 'list existing components and exit',
             DEFAULT => undef
         },
 
@@ -188,6 +154,41 @@ sub app_options()
             NAME    => "chroot=s",
             HELP    => "Chroot to the the directory given as an argument",
             DEFAULT => undef
+        },
+
+        # Advanced options
+        {
+            NAME => 'ignorelock',
+            HELP => 'ignore application lock. Use with care.'
+        },
+
+        {
+            NAME => 'forcelock',
+            HELP => 'take over application lock. Use with care.'
+        },
+
+        {
+            NAME    => 'nodeps',
+            HELP    => 'ignore broken (pre/post) dependencies in configure. Use with care.',
+            DEFAULT => undef
+        },
+
+        {
+            NAME    => 'nodepsnoerrors',
+            HELP    => 'errors from broken (pre/post) dependencies in configure are downgraded to warnings (implies --nodeps --autodeps). Use with care.',
+            DEFAULT => undef
+        },
+
+        {
+            NAME    => 'autodeps!',
+            HELP    => 'expand missing pre/post dependencies in configure. Use with care.',
+            DEFAULT => 1
+        },
+
+        {
+            NAME    => 'allowbrokencomps',
+            HELP    => 'Do not stop overall execution if broken components are found. Use with care.',
+            DEFAULT => 1
         },
     );
 
@@ -464,9 +465,10 @@ unless ($this_app->option("ignorelock")) {
     $this_app->lock() or $this_app->finish(-1);
 }
 
-# nodepsnoerrors implies nodeps
+# nodepsnoerrors implies nodeps and autodeps
 if($this_app->option('nodepsnoerrors')) {
     $this_app->{CONFIG}->set('nodeps', 1);
+    $this_app->{CONFIG}->set('autodeps', 1);
 }
 
 my ($method, $msg);

--- a/src/main/scripts/ncm-ncd
+++ b/src/main/scripts/ncm-ncd
@@ -125,7 +125,7 @@ sub app_options()
         },
 
         {
-            NAME    => 'autodeps',
+            NAME    => 'autodeps=1',
             HELP    => 'expand missing pre/post dependencies in configure',
             DEFAULT => 1
         },

--- a/src/main/scripts/ncm-ncd
+++ b/src/main/scripts/ncm-ncd
@@ -119,6 +119,12 @@ sub app_options()
         },
 
         {
+            NAME    => 'nodepsnoerrors',
+            HELP    => 'errors from broken (pre/post) dependencies in configure are downgraded to warnings (implies --nodeps)',
+            DEFAULT => undef
+        },
+
+        {
             NAME    => 'skip:s',
             HELP    => 'skip one component (only to be used with --all)',
             DEFAULT => undef
@@ -456,6 +462,11 @@ if ($this_app->option('list')) {
 $this_app->verbose('checking for ncm-ncd locks...');
 unless ($this_app->option("ignorelock")) {
     $this_app->lock() or $this_app->finish(-1);
+}
+
+# nodepsnoerrors implies nodeps
+if($this_app->option('nodepsnoerrors')) {
+    $this_app->{CONFIG}->set('nodeps', 1);
 }
 
 my ($method, $msg);

--- a/src/main/scripts/ncm-ncd
+++ b/src/main/scripts/ncm-ncd
@@ -125,7 +125,7 @@ sub app_options()
         },
 
         {
-            NAME    => 'autodeps=1',
+            NAME    => 'autodeps!',
             HELP    => 'expand missing pre/post dependencies in configure',
             DEFAULT => 1
         },

--- a/src/main/scripts/ncm-ncd.pod
+++ b/src/main/scripts/ncm-ncd.pod
@@ -7,7 +7,7 @@ package ncm-ncd;
 ncm-ncd - Node Configuration Dispatcher
       of the NCM (Node Configuration Management) subsystem
 
-      quattor toolsuite http://cern.ch/quattor
+      quattor toolsuite http://quattor.org
 
 =head1 SYNOPSIS
 
@@ -107,11 +107,29 @@ use separate (per component) log files in log directory
 
 =item --nodeps
 
-ignore broken (pre/post) dependencies when invoking configure
+ignore broken dependencies when invoking configure.
+
+missing pre and/or post dependencies are ignored during resolution;
+and during the ordered execution of all components, failing
+predependencies are not considered broken and allow the execution
+of the component.
+
+=item --nodepsnoerrors
+
+errors from dependencies are downgraded to warnings, to make the
+overall ncm-ncd run not fail if a dependency fails. This option implies
+'--nodeps' and '--autodeps'.
+
+A "dependency" here is any component that is not requested/specified
+ via command line (and added to list of components to process via
+'--autodeps', if any).
+
+(If you do not care about dependencies and just want to avoid errors,
+you can also try to use '--nodeps --autodeps=0').
 
 =item --autodeps
 
-expand missing pre/post dependencies in configure
+expand missing pre/post dependencies in configure (default to true).
 
 =item --allowbrokencomps
 

--- a/src/main/scripts/ncm-ncd.pod
+++ b/src/main/scripts/ncm-ncd.pod
@@ -109,7 +109,7 @@ use separate (per component) log files in log directory
 
 ignore broken dependencies when invoking configure.
 
-missing pre and/or post dependencies are ignored during resolution;
+missing pre/post dependencies are ignored during resolution;
 and during the ordered execution of all components, failing
 predependencies are not considered broken and allow the execution
 of the component.
@@ -120,16 +120,17 @@ errors from dependencies are downgraded to warnings, to make the
 overall ncm-ncd run not fail if a dependency fails. This option implies
 '--nodeps' and '--autodeps'.
 
-A "dependency" here is any component that is not requested/specified
+A "dependency" is any component that is not requested/specified
  via command line (and added to list of components to process via
 '--autodeps', if any).
 
 (If you do not care about dependencies and just want to avoid errors,
-you can also try to use '--nodeps --autodeps=0').
+you can also try to use '--nodeps --no-autodeps').
 
 =item --autodeps
 
-expand missing pre/post dependencies in configure (default to true).
+Expand missing pre/post dependencies in configure (default to true).
+(Disable with --no-autodeps.)
 
 =item --allowbrokencomps
 

--- a/src/main/scripts/ncm-ncd.pod
+++ b/src/main/scripts/ncm-ncd.pod
@@ -155,10 +155,10 @@ and during the ordered execution of all components, failing
 predependencies are not considered broken and allow the execution
 of the component.
 
-=item --nodepsnoerrors
+=item --ignore-errors-from-dependencies
 
 errors from dependencies are downgraded to warnings, to make the
-overall ncm-ncd run not fail if a dependency fails. This option implies
+overall ncm-ncd run pass if a dependency fails. This option implies
 '--nodeps' and '--autodeps'. Use with care.
 
 A "dependency" is any component that is not requested/specified
@@ -171,7 +171,7 @@ you can also try to use '--nodeps --no-autodeps').
 =item --autodeps
 
 Expand missing pre/post dependencies in configure (default to true).
-(Disable with --no-autodeps. Use with care.)
+(Disable with --no-autodeps. Use --no-autodeps with care.)
 
 =item --allowbrokencomps
 

--- a/src/main/scripts/ncm-ncd.pod
+++ b/src/main/scripts/ncm-ncd.pod
@@ -43,6 +43,12 @@ parameter.
 
 =over 4
 
+=item --list
+
+Does nothing but list all found components, in the following format:
+
+name - active? - installed?
+
 =item --configure
 
 run the 'configure' method for <component1,2..> (default option). For running configure on all components, use --configure --all.
@@ -85,14 +91,6 @@ no state files will be maintained.
 
 wait a maximum of 'n' seconds between retries.
 
-=item --ignorelock
-
-Ignore existing application lock. Use with care.
-
-=item --forcelock
-
-Take over application lock. Use with care.
-
 =item --useprofile <profile_id>
 
 use <profile_id> as NVA-API configuration profile ID (default: latest)
@@ -104,44 +102,6 @@ CCM cache root directory (optional, otherwise CCM default taken)
 =item --multilog
 
 use separate (per component) log files in log directory
-
-=item --nodeps
-
-ignore broken dependencies when invoking configure.
-
-missing pre/post dependencies are ignored during resolution;
-and during the ordered execution of all components, failing
-predependencies are not considered broken and allow the execution
-of the component.
-
-=item --nodepsnoerrors
-
-errors from dependencies are downgraded to warnings, to make the
-overall ncm-ncd run not fail if a dependency fails. This option implies
-'--nodeps' and '--autodeps'.
-
-A "dependency" is any component that is not requested/specified
- via command line (and added to list of components to process via
-'--autodeps', if any).
-
-(If you do not care about dependencies and just want to avoid errors,
-you can also try to use '--nodeps --no-autodeps').
-
-=item --autodeps
-
-Expand missing pre/post dependencies in configure (default to true).
-(Disable with --no-autodeps.)
-
-=item --allowbrokencomps
-
-Do not stop overall execution if 'broken' components are found, just ignore
-these ('broken' components: component file missing or not instantiable)
-
-=item --list
-
-Does nothing but list all found components, in the following format:
-
-name - active? - installed?
 
 =item --pre-hook
 
@@ -168,6 +128,55 @@ A value of 0 means no time out.  By default they time out after 5 minutes.
 
 Chroot to the directory given as an argument.  If it's not possible to
 chroot, C<ncm-ncd> will die.
+
+=back
+
+=head2 Advanced Options
+
+Following options are advanced options (typically used for debugging and/or testing).
+Use with care.
+
+=over
+
+=item --ignorelock
+
+Ignore existing application lock. Use with care.
+
+=item --forcelock
+
+Take over application lock. Use with care.
+
+=item --nodeps
+
+ignore broken dependencies when invoking configure. Use with care.
+
+missing pre/post dependencies are ignored during resolution;
+and during the ordered execution of all components, failing
+predependencies are not considered broken and allow the execution
+of the component.
+
+=item --nodepsnoerrors
+
+errors from dependencies are downgraded to warnings, to make the
+overall ncm-ncd run not fail if a dependency fails. This option implies
+'--nodeps' and '--autodeps'. Use with care.
+
+A "dependency" is any component that is not requested/specified
+ via command line (and added to list of components to process via
+'--autodeps', if any).
+
+(If you do not care about dependencies and just want to avoid errors,
+you can also try to use '--nodeps --no-autodeps').
+
+=item --autodeps
+
+Expand missing pre/post dependencies in configure (default to true).
+(Disable with --no-autodeps. Use with care.)
+
+=item --allowbrokencomps
+
+Do not stop overall execution if 'broken' components are found, just ignore
+these ('broken' components: component file missing or not instantiable). Use with care.
 
 =back
 

--- a/src/test/perl/component-proxy-list.t
+++ b/src/test/perl/component-proxy-list.t
@@ -1,0 +1,243 @@
+use strict;
+use warnings;
+use Test::More;
+use Test::Quattor qw(component-proxy-list);
+use NCD::ComponentProxyList;
+use CAF::Object;
+use Test::MockModule;
+
+$CAF::Object::NoAction = 1;
+
+our $this_app;
+
+BEGIN {
+    $this_app = CAF::Application->new('app');
+    $this_app->{CONFIG}->define("state");
+    $this_app->{CONFIG}->define("autodeps");
+    $this_app->{CONFIG}->set('autodeps', 1);
+    $this_app->{CONFIG}->define("noaction");
+    $this_app->{CONFIG}->set('noaction', 1);
+    $this_app->{CONFIG}->define("template-path");
+    $this_app->{CONFIG}->set('template-path', "doesnotexist");
+    $this_app->{CONFIG}->define("nodeps");
+    $this_app->{CONFIG}->set('nodeps', 0);
+}
+
+my $cfg = get_config_for_profile('component-proxy-list');
+
+my $mock = Test::MockModule->new('NCD::ComponentProxyList');
+
+my $WARN = 0;
+$mock->mock('warn', sub {
+    $WARN++;
+    diag("WARN ", join('', @_));
+});
+
+my $ERROR = 0;
+$mock->mock('error', sub {
+    $ERROR++;
+    diag("ERROR ", join('', @_));
+});
+
+=head1
+
+Test Init
+
+=cut
+
+# mock a failing _getComponents
+$mock->mock('_getComponents', undef);
+
+# no skip; random order
+my @comps = qw(ee bb dd);
+my $cpl = NCD::ComponentProxyList->new($cfg, undef, @comps);
+isa_ok($cpl, 'NCD::ComponentProxyList', 'init returns a NCD::ComponentProxyList instance');
+
+is_deeply($cpl->{CCM_CONFIG}, $cfg, "Configuration instance CCM_CONFIG");
+is_deeply($cpl->{SKIP}, [], "Empty skip list");
+is_deeply($cpl->{NAMES}, \@comps, "Correct list of initial components");
+
+ok(! defined($cpl->{CLIST}), "Component proxies list is undefined in case of failure of _getComponents");
+
+$mock->unmock('_getComponents');
+
+=head1
+
+Test _parse_skip_args
+
+=cut
+
+my $skip = NCD::ComponentProxyList::_parse_skip_args("a,b,c");
+is_deeply($skip, ['a', 'b', 'c'], "Correct list of componets to skip returned");
+$skip = NCD::ComponentProxyList::_parse_skip_args();
+is_deeply($skip, [], "Empty list of componets to skip returned");
+
+=head1
+
+get_all_components
+
+=cut
+
+my %comps = $cpl->get_all_components();
+is_deeply(\%comps, {
+    'aa' => 1,
+    'bb' => 1,
+    'cc' => 1,
+    'dd' => 1,
+    'ee' => 1,
+    'ff' => 0,
+    'gg' => 1,
+          }, "All components and their active status");
+
+=head1
+
+skip_components
+
+=cut
+
+# Take copy
+my $comps = { %comps };
+
+$cpl->{SKIP} = ['aa', 'ee', 'xx'];
+my %toskip = $cpl->skip_components($comps);
+is_deeply($comps, {
+    'bb' => 1,
+    'cc' => 1,
+    'dd' => 1,
+    'ff' => 0,
+    'gg' => 1,
+          }, "Filtered hashref of comps remains");
+is_deeply(\%toskip, {
+    'aa' => 1,
+    'ee' => 1,
+    'xx' => 0,
+          }, "Status of to be skipped components");
+
+=head1
+
+get_proxies
+
+=cut
+
+# autodeps on, nodeps off
+$WARN=0;
+$ERROR=0;
+
+$comps = { %comps };
+
+# delete aa, predep of almost everything
+delete $comps->{aa};
+# delete dd, post dep of bb
+delete $comps->{dd};
+# delete gg, has no deps on anything
+delete $comps->{gg};
+# delete ff, since not active; can't make proxy
+delete $comps->{ff};
+
+my @pxs = $cpl->get_proxies($comps);
+is_deeply($comps, {
+    'aa' => 1,
+    'bb' => 1,
+    'cc' => 1,
+    'dd' => 1,
+    'ee' => 1,
+    # no gg
+          }, "Modified comps after recursive dependency search");
+my @names = map { $_->name() } @pxs;
+is_deeply(\@names, ['bb','cc','ee','aa','dd'],
+          "Expected names of components proxies");
+is($ERROR, 0, "no errors logged");
+is($WARN, 0, "no warn logged");
+
+# autodeps off, nodeps off
+# no recursive search due to no missing deps from autodeps
+# no errors on missing deps due to nodeps
+
+$WARN=0;
+$ERROR=0;
+
+$this_app->{CONFIG}->set('autodeps', 0);
+
+$comps = { %comps };
+
+# delete aa, predep of almost everything
+delete $comps->{aa};
+# delete dd, post dep of bb
+delete $comps->{dd};
+# delete gg, has no deps on anything
+delete $comps->{gg};
+# delete ff, since not active; can't make proxy
+delete $comps->{ff};
+
+@pxs = $cpl->get_proxies($comps);
+is_deeply($comps, {
+    'bb' => 1,
+    'cc' => 1,
+    'ee' => 1,
+          }, "Modified comps after search (autodeps off, nodeps off)");
+
+@names = map { $_->name() } @pxs;
+is_deeply(\@names, ['bb','cc','ee'],
+          "Expected names of components proxies with autodeps off");
+is($ERROR, 0, "no errors logged");
+is($WARN, 2, "warn logged (aa missing twice)");
+
+# turn autodeps on again
+$this_app->{CONFIG}->set('autodeps', 1);
+
+=head1
+
+reportComponents
+
+=cut
+
+
+my @report;
+$mock->mock('report', sub {
+    my ($self, @args) = @_;
+    my $msg = join('', @args);
+    push(@report, $msg);
+});
+
+$cpl->{CLIST} = \@pxs;
+$cpl->reportComponents();
+
+is_deeply(\@report, [
+              'active components found inside profile /software/components:',
+              'name           file?  predeps                      postdeps                     ',
+              '-------------------------------------------------------------------',
+              'bb:            no     aa                           cc,dd                        ',
+              'cc:            no                                                               ',
+              'ee:            no     aa                                                        '
+          ], "report as expected");
+
+$mock->unmock('report');
+$cpl->{CLIST} = undef;
+
+=head1
+
+pre_config_actions / post_config_actions
+
+=cut
+
+# there's nothing in the test framework to access the options passed
+
+$comps = { %comps };
+
+set_desired_output("/test/pre", "preout");
+set_command_status("/test/pre", 0);
+
+ok($cpl->pre_config_actions("/test/pre", 10, $comps),
+   "Pre hook ran succesful");
+
+set_desired_output("/test/post", "postout");
+set_command_status("/test/post", 0);
+
+ok($cpl->post_config_actions("/test/post", 10, $comps),
+   "Post hook ran succesful");
+
+ok(command_history_ok(["/test/pre", "/test/post"]),
+   "Pre and post hook ran");
+
+
+done_testing();

--- a/src/test/perl/component-proxy-list.t
+++ b/src/test/perl/component-proxy-list.t
@@ -564,9 +564,7 @@ foreach my $c (sort keys(%$topoafter)) {
 }
 ok($toposortfail, "toposort detected loop and returned false");
 
-# TODO
-# run_all_components
-# executeConfigComponents
-# executeUnconfigComponent
+# run_all_components tested in runall.t
+# executeConfigComponents / executeUnconfigComponent are tested in execute-config-components
 
 done_testing();

--- a/src/test/perl/execute-config-components.t
+++ b/src/test/perl/execute-config-components.t
@@ -56,6 +56,17 @@ $mockcomponent->mock("executeConfigure", \&long_successful_configure);
 $mocklist->mock("pre_config_actions", 1);
 $mocklist->mock("post_config_actions", 1);
 
+$mocklist->mock('debug', sub (@) {
+    my $self= shift;
+    diag("DEBUG ", join('', @_));
+});
+
+
+$mocklist->mock('verbose', sub (@) {
+    my $self= shift;
+    diag("VERBOSE ", join('', @_));
+});
+
 =pod
 
 =head1 DESCRIPTION
@@ -78,13 +89,17 @@ my $cfg = get_config_for_profile('execute-config-components');
 
 
 my $cl = NCD::ComponentProxyList->new($cfg, undef, "acomponent");
-
-#$cl->{CLIST} = [NCD::ComponentProxy->new('acomponent', $cfg)];
+my @clist = map {$_->name()} @{$cl->{CLIST}};
+is_deeply(\@clist, ['acomponent'],
+          "expected list of component proxies found");
+my $sorted = $cl->_sortComponents($cl->{CLIST});
+my @names = map {$_->name()} @$sorted;
+is_deeply(\@names, ['acomponent'], "Expected sorted components");
 
 my $err = $cl->executeConfigComponents();
 
 is($err->{ERRORS}, 0, "No errors reported");
-is($err->{WARNINGS}, 5, "No warnings reported");
+is($err->{WARNINGS}, 5, "5 warnings reported");
 is(scalar(keys(%{$err->{WARN_COMPS}})), 1,
    "Components with warnings are reported");
 

--- a/src/test/perl/runall.t
+++ b/src/test/perl/runall.t
@@ -11,10 +11,13 @@ use CAF::Object;
 
 $CAF::Object::NoAction = 1;
 
+our $this_app;
+
 BEGIN {
-    our $this_app = CAF::Application->new('app');
+    $this_app = CAF::Application->new('app');
     $this_app->{CONFIG}->define("state");
     $this_app->{CONFIG}->define("autodeps");
+    $this_app->{CONFIG}->set('autodeps', 1);
     $this_app->{CONFIG}->define("noaction");
     $this_app->{CONFIG}->set('noaction', 1);
     $this_app->{CONFIG}->define("template-path");
@@ -33,9 +36,12 @@ Readonly::Hash my %INIT_GLOBAL_STATUS => {
 my $mockcomponent = Test::MockModule->new("NCD::ComponentProxy");
 my $mocklist = Test::MockModule->new("NCD::ComponentProxyList");
 
+my $configure;
+
 sub long_successful_configure
 {
     my $self = shift;
+    $configure++;
 
     if ($self->{NAME} eq 'acomponent') {
         return {ERRORS => 0, WARNINGS => 5};
@@ -46,6 +52,7 @@ sub long_successful_configure
 
 sub long_failed_configure
 {
+    $configure++;
     return {ERRORS => 1, WARNINGS => 0};
 }
 
@@ -53,6 +60,7 @@ sub execute_dependency_failed
 {
     my $self = shift;
 
+    $configure++;
     is($self->{NAME}, "acomponent",
        "Components with failed dependencies are not called: $self->{NAME}");
     return {ERRORS => 1, WARNINGS => 0};
@@ -62,6 +70,7 @@ sub execute_failed_nodeps
 {
     my $self = shift;
 
+    $configure++;
     if ($self->{NAME} eq "acomponent") {
         return {ERRORS => 1, WARNINGS => 0};
     }
@@ -95,6 +104,9 @@ my $err = {%INIT_GLOBAL_STATUS};
 
 my $cfg = get_config_for_profile('runall-comps');
 
+# acomponent: no pre/post deps
+# anotherone: acomponent pre dep, no post dep
+# yetonemore: no pre dep, anotherone post dep
 my @cmp = (NCD::ComponentProxy->new('acomponent', $cfg),
            NCD::ComponentProxy->new('anotherone', $cfg));
 
@@ -103,12 +115,14 @@ my $cl = NCD::ComponentProxyList->new($cfg, undef, "acomponent");
 
 $cl->{CLIST} = [$cmp[0]];
 
+$configure = 0;
 $cl->run_all_components($cl->{CLIST}, 0, $err);
 
 is($err->{ERRORS}, 0, "No errors reported");
 is($err->{WARNINGS}, 5, "No warnings reported");
 is(scalar(keys(%{$err->{WARN_COMPS}})), 1,
    "Components with warnings are reported");
+is($configure, 1, "$configure components configured");
 
 =pod
 
@@ -123,11 +137,13 @@ is(scalar(keys(%{$err->{WARN_COMPS}})), 1,
 $err = {%INIT_GLOBAL_STATUS};
 $cl->{CLIST} = \@cmp;
 
+$configure = 0;
 $cl->run_all_components($cl->{CLIST}, 0, $err);
 is($err->{ERRORS}, 0, "No errors detected");
 is($err->{WARNINGS}, 15, "Warnings are summed up");
 is(scalar(keys(%{$err->{WARN_COMPS}})), 2,
    "Components with warnings are reported");
+is($configure, 2, "$configure components configured");
 
 =pod
 
@@ -138,9 +154,11 @@ is(scalar(keys(%{$err->{WARN_COMPS}})), 2,
 =cut
 
 $err = {%INIT_GLOBAL_STATUS};
+$configure = 0;
 $cl->run_all_components($cl->{CLIST}, 1, $err);
 is($err->{ERRORS}, 0, "No errors when nodeps and all dependencies satisfied");
 is($err->{WARNINGS}, 15, "Warnings correctly aggregated with nodeps");
+is($configure, 2, "$configure components configured");
 
 =pod
 
@@ -158,10 +176,13 @@ $mockcomponent->mock("executeConfigure", \&long_failed_configure);
 
 $err = {%INIT_GLOBAL_STATUS};
 
+$configure = 0;
 $cl->run_all_components([$cmp[0]], 0, $err);
+is($err->{WARNINGS}, 0, "Warnings are summed up");
 is($err->{ERRORS}, 1, "All failed components are detected");
 is(scalar(keys(%{$err->{ERR_COMPS}})), 1,
    "Components are added to the error list");
+is($configure, 1, "$configure components configured");
 
 =pod
 
@@ -173,15 +194,32 @@ $err = {%INIT_GLOBAL_STATUS};
 
 $mockcomponent->mock("executeConfigure", \&execute_dependency_failed);
 
+$configure = 0;
 $cl->run_all_components(\@cmp, 0, $err);
+is($err->{WARNINGS}, 0, "Warnings are summed up");
 is($err->{ERRORS}, 2, "Errors reported when pre-dependencies fail");
+is($configure, 1, "$configure components configured");
 
 $err = {%INIT_GLOBAL_STATUS};
 
 $mockcomponent->mock("executeConfigure", \&execute_failed_nodeps);
 
+$configure = 0;
 $cl->run_all_components(\@cmp, 1, $err);
+is($err->{WARNINGS}, 5, "Warnings are summed up");
 is($err->{ERRORS}, 4, "All components get executed with --nodeps");
+is($configure, 2, "$configure components configured");
 
+# nodepsnoerrors errors of failed comp are converted in warnings
+$this_app->{CONFIG}->define("nodepsnoerrors");
+$this_app->{CONFIG}->set('nodepsnoerrors', 1);
+
+$err = {%INIT_GLOBAL_STATUS};
+$configure = 0;
+$cl->{NAMES} = ['anotherone']; # acomponent is not requested, but is dependency via auotdeps
+$cl->run_all_components(\@cmp, 1, $err);
+is($err->{WARNINGS}, 6, "Warnings are summed up (one error converted in warning)");
+is($err->{ERRORS}, 3, "All components get executed with --nodeps (but one error converted in warning)");
+is($configure, 2, "$configure components configured");
 
 done_testing();

--- a/src/test/perl/runall.t
+++ b/src/test/perl/runall.t
@@ -210,9 +210,9 @@ is($err->{WARNINGS}, 5, "Warnings are summed up");
 is($err->{ERRORS}, 4, "All components get executed with --nodeps");
 is($configure, 2, "$configure components configured");
 
-# nodepsnoerrors errors of failed comp are converted in warnings
-$this_app->{CONFIG}->define("nodepsnoerrors");
-$this_app->{CONFIG}->set('nodepsnoerrors', 1);
+# ignore-errors-from-dependencies errors of failed comp are converted in warnings
+$this_app->{CONFIG}->define("ignore-errors-from-dependencies");
+$this_app->{CONFIG}->set('ignore-errors-from-dependencies', 1);
 
 $err = {%INIT_GLOBAL_STATUS};
 $configure = 0;

--- a/src/test/resources/component-proxy-list.pan
+++ b/src/test/resources/component-proxy-list.pan
@@ -1,0 +1,23 @@
+object template component-proxy-list;
+
+"/software/components" = {
+    # Can't have single letter components
+    foreach (idx;comp; list('aa', 'bb', 'cc', 'dd', 'ee', 'ff', 'gg')) {
+        SELF[comp] = create('component-structure');
+    };
+    SELF;
+};
+
+"/software/components/bb/dependencies/pre" = append('aa');
+"/software/components/bb/dependencies/post" = append('cc');
+"/software/components/bb/dependencies/post" = append('dd');
+"/software/components/dd/dependencies/pre" = append('aa');
+"/software/components/dd/dependencies/pre" = append('bb');
+"/software/components/ee/dependencies/pre" = append('aa');
+
+"/software/components/ff/dependencies/pre" = append('aa');
+"/software/components/ff/active" = false;
+
+# failure, ff2 can't be proxy because it's inactive
+#"/software/components/ff2/active" = false;
+#"/software/components/aa/dependencies/post" = append('ff2');

--- a/src/test/resources/component-structure.pan
+++ b/src/test/resources/component-structure.pan
@@ -1,0 +1,6 @@
+structure template component-structure;
+
+"active" = true;
+"dependencies/pre" = list();
+"dependencies/post" = list();
+"dispatch"  = true;

--- a/src/test/resources/runall-comps.pan
+++ b/src/test/resources/runall-comps.pan
@@ -6,11 +6,13 @@ prefix "/software/components";
 "acomponent/dependencies/pre" = list();
 "acomponent/dependencies/post" = list();
 "acomponent/dispatch"  = true;
+
 "anotherone/active" = true;
 "anotherone/dependencies/pre" = list("acomponent");
 "anotherone/dependencies/post" = list();
 "anotherone/dispatch"  = true;
+
+"yetonemore/active" = true;
 "yetonemore/dependencies/pre" = list();
 "yetonemore/dependencies/post" = list("anotherone");
 "yetonemore/dispatch" = true;
-"yetonemore/active" = true;


### PR DESCRIPTION
Give the admin advanced control over the dependencies, in particular to skip them altogether via `--nodeps --no-autodeps` or run the postdependencies best-effort via `--nodepsnoerrors`.

Another use case is in AII where  the initial `ncm-ncd --co spma` during `postinstall` can fail due to postdependencies of `spma` (e.g. `chkconfig`); which is OK in this specific case since no other components ran.