### PR TITLE
ignore NCM:: namespace for all unittests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,403 +1,344 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-
   <modelVersion>4.0.0</modelVersion>
-
   <groupId>org.quattor.cfg.module</groupId>
   <artifactId>ncm-ncd</artifactId>
-
   <packaging>pom</packaging>
   <version>16.2.1-SNAPSHOT</version>
-  <name>NCD is the frontend for invoking NCM components.</name>
-
+  <name>NCD is the front-end for invoking NCM components</name>
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.48</version>
+    <version>1.49</version>
   </parent>
-
   <scm>
     <connection>scm:git:git://github.com/quattor/ncm-ncd.git</connection>
     <developerConnection>scm:git:git@github.com:quattor/ncm-ncd.git</developerConnection>
     <url>https://github.com/quattor/ncm-ncd</url>
   </scm>
-
   <developers>
     <developer>
       <name>Luis Fernando Muñoz Mejías</name>
       <email>Luis.Munoz@UGent.be</email>
     </developer>
   </developers>
-
   <contributors>
     <contributor>
       <name>Germán Cancio Meliá</name>
       <email>German.Cancio@cern.ch</email>
       <roles>
-	<role>author</role>
+        <role>author</role>
       </roles>
     </contributor>
     <contributor>
       <name>Marco Emilio Poleggi</name>
       <roles>
-	<role>author</role>
+        <role>author</role>
       </roles>
     </contributor>
     <contributor>
       <name>Nick Williams</name>
       <email>nick.williams@morganstanley.com</email>
       <roles>
-	<role>contributor</role>
+        <role>contributor</role>
       </roles>
     </contributor>
   </contributors>
-
   <build>
     <pluginManagement>
       <plugins>
-	<plugin>
-	  <groupId>org.codehaus.mojo</groupId>
-	  <artifactId>rpm-maven-plugin</artifactId>
-	  <configuration>
-	    <summary>NCD is the frontend for invoking NCM components.</summary>
-	    <name>ncm-ncd</name>
-	    <provides>
-	      <provide>ncm-ncd</provide>
-	    </provides>
-	    <needarch>noarch</needarch>
-	    <requires combine.self="override">
-	      <require>perl-CAF</require>
-	      <require>ccm</require>
-	    </requires>
-	    <mappings combine.self="override">
-	      <mapping>
-		<directory>/var/lock/quattor</directory>
-		<directoryIncluded>true</directoryIncluded>
-		<configuration>false</configuration>
-		<groupname>root</groupname>
-		<filemode>755</filemode>
-		<username>root</username>
-	      </mapping>
-	      <mapping>
-		<directory>/var/tmp/ncm</directory>
-		<directoryIncluded>true</directoryIncluded>
-		<configuration>false</configuration>
-		<groupname>root</groupname>
-		<username>root</username>
-		<filemode>755</filemode>
-	      </mapping>
-	      <mapping>
-		<directory>/var/log/ncm</directory>
-		<directoryIncluded>true</directoryIncluded>
-		<groupname>root</groupname>
-		<username>root</username>
-		<filemode>700</filemode>
-	      </mapping>
-	      <mapping>
-		<directory>/var/run/quattor-components</directory>
-		<directoryIncluded>true</directoryIncluded>
-		<filemode>755</filemode>
-		<configuration>false</configuration>
-		<groupname>root</groupname>
-		<username>root</username>
-	      </mapping>
-	      <mapping>
-		<directory>/usr/sbin</directory>
-		<filemode>755</filemode>
-		<username>root</username>
-		<groupname>root</groupname>
-		<directoryIncluded>false</directoryIncluded>
-		<sources>
-		  <source>
-		    <location>target/sbin</location>
-		    <excludes>
-		      <exclude>*.pod</exclude>
-		    </excludes>
-		  </source>
-		</sources>
-	      </mapping>
-	      <mapping>
-		<directory>/usr/share/doc/${project.artifactId}-${project.version}</directory>
-		<filemode>644</filemode>
-		<username>root</username>
-		<groupname>root</groupname>
-		<documentation>true</documentation>
-		<directoryIncluded>false</directoryIncluded>
-		<sources>
-		  <source>
-		    <location>${basedir}</location>
-		    <includes>
-		      <include>ChangeLog</include>
-		    </includes>
-		  </source>
-		</sources>
-	      </mapping>
-	      <mapping>
-		<directory>/usr/lib</directory>
-		<filemode>644</filemode>
-		<username>root</username>
-		<groupname>root</groupname>
-		<directoryIncluded>false</directoryIncluded>
-		<sources>
-		  <source>
-		    <location>target/lib</location>
-		    <excludes>
-		      <exclude>ncm-ncd.pod</exclude>
-		    </excludes>
-		  </source>
-		</sources>
-		<documentation>false</documentation>
-		<configuration>false</configuration>
-	      </mapping>
-	      <mapping>
-		<directory>/usr/share/man</directory>
-		<filemode>644</filemode>
-		<username>root</username>
-		<groupname>root</groupname>
-		<documentation>true</documentation>
-		<directoryIncluded>false</directoryIncluded>
-		<sources>
-		  <source>
-		    <location>target/doc/man</location>
-		  </source>
-		</sources>
-	      </mapping>
-	      <mapping>
-		<directory>/etc</directory>
-		<filemode>644</filemode>
-		<username>root</username>
-		<groupname>root</groupname>
-		<documentation>false</documentation>
-		<configuration>noreplace</configuration>
-		<directoryIncluded>false</directoryIncluded>
-		<sources>
-		  <source>
-		    <location>${project.build.directory}/etc</location>
-		    <includes>
-		      <include>**/*</include>
-		    </includes>
-		  </source>
-		</sources>
-	      </mapping>
-	    </mappings>
-	  </configuration>
-	</plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>rpm-maven-plugin</artifactId>
+          <configuration>
+            <summary>NCD is the front-end for invoking NCM components</summary>
+            <url>https://github.com/quattor/ncm-ncd/tree/master</url>
+            <name>ncm-ncd</name>
+            <mappings combine.self="override">
+              <mapping>
+                <directory>/var/log/ncm</directory>
+                <directoryIncluded>true</directoryIncluded>
+              </mapping>
+              <mapping>
+                <directory>/usr/sbin</directory>
+                <filemode>755</filemode>
+                <directoryIncluded>false</directoryIncluded>
+                <sources>
+                  <source>
+                    <location>target/sbin</location>
+                    <excludes>
+                      <exclude>*.pod</exclude>
+                    </excludes>
+                  </source>
+                </sources>
+              </mapping>
+              <mapping>
+                <directory>/usr/share/doc/${project.artifactId}-${project.version}</directory>
+                <documentation>true</documentation>
+                <directoryIncluded>false</directoryIncluded>
+                <sources>
+                  <source>
+                    <location>${basedir}</location>
+                    <includes>
+                      <include>ChangeLog</include>
+                    </includes>
+                  </source>
+                </sources>
+              </mapping>
+              <mapping>
+                <directory>/usr/lib</directory>
+                <directoryIncluded>false</directoryIncluded>
+                <sources>
+                  <source>
+                    <location>target/lib</location>
+                    <excludes>
+                      <exclude>ncm-ncd.pod</exclude>
+                    </excludes>
+                  </source>
+                </sources>
+                <documentation>false</documentation>
+                <configuration>false</configuration>
+              </mapping>
+              <mapping>
+                <directory>/usr/share/man</directory>
+                <documentation>true</documentation>
+                <directoryIncluded>false</directoryIncluded>
+                <sources>
+                  <source>
+                    <location>target/doc/man</location>
+                  </source>
+                </sources>
+              </mapping>
+              <mapping>
+                <directory>/etc</directory>
+                <documentation>false</documentation>
+                <configuration>noreplace</configuration>
+                <directoryIncluded>false</directoryIncluded>
+                <sources>
+                  <source>
+                    <location>${project.build.directory}/etc</location>
+                    <includes>
+                      <include>**/*</include>
+                    </includes>
+                  </source>
+                </sources>
+              </mapping>
+            </mappings>
+          </configuration>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>
       <plugin>
-	<groupId>org.apache.maven.plugins</groupId>
-	<artifactId>maven-resources-plugin</artifactId>
-	<executions>
-	  <execution>
-	    <id>filter-script-sources</id>
-	    <phase>process-sources</phase>
-	    <goals>
-	      <goal>copy-resources</goal>
-	    </goals>
-	    <configuration>
-	      <outputDirectory>${project.build.directory}/sbin</outputDirectory>
-	      <resources>
-		<resource>
-		  <directory>src/main/scripts</directory>
-		  <filtering>true</filtering>
-		  <includes>
-		    <include>**/*</include>
-		  </includes>
-		</resource>
-	      </resources>
-	    </configuration>
-	  </execution>
-	  <execution>
-	    <id>filter-config</id>
-	    <phase>process-sources</phase>
-	    <goals>
-	      <goal>copy-resources</goal>
-	    </goals>
-	    <configuration>
-	      <outputDirectory>${project.build.directory}/etc</outputDirectory>
-	      <resources>
-		<resource>
-		  <directory>src/main/config</directory>
-		  <filtering>true</filtering>
-		  <includes>
-		    <include>**/*</include>
-		  </includes>
-		</resource>
-	      </resources>
-	    </configuration>
-	  </execution>
-	  <execution>
-	    <id>filter-perl-sources</id>
-	    <phase>process-sources</phase>
-	    <goals>
-	      <goal>copy-resources</goal>
-	    </goals>
-	    <configuration>
-	      <outputDirectory>${project.build.directory}/lib/perl/NCD</outputDirectory>
-	      <resources>
-		<resource>
-		  <directory>src/main/perl</directory>
-		  <filtering>true</filtering>
-		  <includes>
-		    <include>ComponentProxy.pm</include>
-		    <include>ComponentProxyList.pm</include>
-		  </includes>
-		</resource>
-	      </resources>
-	    </configuration>
-	  </execution>
-	  <execution>
-	    <id>filter-ncm-component</id>
-	    <phase>process-sources</phase>
-	    <goals>
-	      <goal>copy-resources</goal>
-	    </goals>
-	    <configuration>
-	      <outputDirectory>${project.build.directory}/lib/perl/NCM</outputDirectory>
-	      <resources>
-		<resource>
-		  <directory>src/main/perl</directory>
-		  <filtering>true</filtering>
-		  <excludes>
-		    <exclude>ComponentProxy.pm</exclude>
-		    <exclude>ComponentProxyList.pm</exclude>
-		  </excludes>
-		</resource>
-	      </resources>
-	    </configuration>
-	  </execution>
-	  <execution>
-	    <id>filter-pod-sources</id>
-	    <phase>process-sources</phase>
-	    <goals>
-	      <goal>copy-resources</goal>
-	    </goals>
-	    <configuration self.combine="override">
-	      <outputDirectory>${project.build.directory}/doc/pod/NCM</outputDirectory>
-	      <resources>
-		<resource>
-		  <directory>src/main/perl</directory>
-		  <includes>
-		    <include>*.pm</include>
-		  </includes>
-		  <excludes>
-		    <exclude>ComponentProxy.pm</exclude>
-		    <exclude>ComponentProxyList.pm</exclude>
-		  </excludes>
-
-		  <filtering>true</filtering>
-		</resource>
-	      </resources>
-	    </configuration>
-	  </execution>
-	  <execution>
-	    <id>filter-ncd-pod-sources</id>
-	    <phase>process-sources</phase>
-	    <goals>
-	      <goal>copy-resources</goal>
-	    </goals>
-	    <configuration self.combine="override">
-	      <outputDirectory>${project.build.directory}/doc/pod/NCD</outputDirectory>
-	      <resources>
-		<resource>
-		  <directory>src/main/perl</directory>
-		  <includes>
-		    <include>ComponentProxy.pm</include>
-		    <include>ComponentProxyList.pm</include>
-		  </includes>
-		  <filtering>true</filtering>
-		</resource>
-	      </resources>
-	    </configuration>
-	  </execution>
-	  <!-- The pod2man script requires a somewhat matching layout
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>filter-script-sources</id>
+            <phase>process-sources</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}/sbin</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>src/main/scripts</directory>
+                  <filtering>true</filtering>
+                  <includes>
+                    <include>**/*</include>
+                  </includes>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+          <execution>
+            <id>filter-config</id>
+            <phase>process-sources</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}/etc</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>src/main/config</directory>
+                  <filtering>true</filtering>
+                  <includes>
+                    <include>**/*</include>
+                  </includes>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+          <execution>
+            <id>filter-perl-sources</id>
+            <phase>process-sources</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}/lib/perl/NCD</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>src/main/perl</directory>
+                  <filtering>true</filtering>
+                  <includes>
+                    <include>ComponentProxy.pm</include>
+                    <include>ComponentProxyList.pm</include>
+                  </includes>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+          <execution>
+            <id>filter-ncm-component</id>
+            <phase>process-sources</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}/lib/perl/NCM</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>src/main/perl</directory>
+                  <filtering>true</filtering>
+                  <excludes>
+                    <exclude>ComponentProxy.pm</exclude>
+                    <exclude>ComponentProxyList.pm</exclude>
+                  </excludes>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+          <execution>
+            <id>filter-pod-sources</id>
+            <phase>process-sources</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration self.combine="override">
+              <outputDirectory>${project.build.directory}/doc/pod/NCM</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>src/main/perl</directory>
+                  <includes>
+                    <include>*.pm</include>
+                  </includes>
+                  <excludes>
+                    <exclude>ComponentProxy.pm</exclude>
+                    <exclude>ComponentProxyList.pm</exclude>
+                  </excludes>
+                  <filtering>true</filtering>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+          <execution>
+            <id>filter-ncd-pod-sources</id>
+            <phase>process-sources</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration self.combine="override">
+              <outputDirectory>${project.build.directory}/doc/pod/NCD</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>src/main/perl</directory>
+                  <includes>
+                    <include>ComponentProxy.pm</include>
+                    <include>ComponentProxyList.pm</include>
+                  </includes>
+                  <filtering>true</filtering>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+          <!-- The pod2man script requires a somewhat matching layout
 	       for the target/lib/perl and the target/doc/pod. The
 	       following two executions do that. We'll have to ignore
 	       the intermediate files from the RPM. -->
-	  <execution>
-	    <id>mimick-ncm-ncd-man</id>
-	    <phase>process-sources</phase>
-	    <goals>
-	      <goal>copy-resources</goal>
-	    </goals>
-	    <configuration>
-	      <outputDirectory>${project.build.directory}/doc/pod</outputDirectory>
-	      <resources>
-		<resource>
-		  <directory>src/main/scripts</directory>
-		  <includes>
-		    <include>*.pod</include>
-		  </includes>
-		  <filtering>true</filtering>
-		</resource>
-	      </resources>
-	    </configuration>
-	  </execution>
-	  <execution>
-	    <id>mimick-ncm-ncd-man-pod</id>
-	    <phase>process-sources</phase>
-	    <goals>
-	      <goal>copy-resources</goal>
-	    </goals>
-	    <configuration>
-	      <outputDirectory>${project.build.directory}/lib/perl</outputDirectory>
-	      <resources>
-		<resource>
-		  <directory>src/main/scripts</directory>
-		  <includes>
-		    <include>*.pod</include>
-		  </includes>
-		  <filtering>true</filtering>
-		</resource>
-	      </resources>
-	    </configuration>
-	  </execution>
-	</executions>
+          <execution>
+            <id>mimick-ncm-ncd-man</id>
+            <phase>process-sources</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}/doc/pod</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>src/main/scripts</directory>
+                  <includes>
+                    <include>*.pod</include>
+                  </includes>
+                  <filtering>true</filtering>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+          <execution>
+            <id>mimick-ncm-ncd-man-pod</id>
+            <phase>process-sources</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}/lib/perl</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>src/main/scripts</directory>
+                  <includes>
+                    <include>*.pod</include>
+                  </includes>
+                  <filtering>true</filtering>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
-	<artifactId>maven-antrun-plugin</artifactId>
-	<executions>
-	  <execution>
-	    <id>rename-pod-sources</id>
-	    <phase>process-sources</phase>
-	    <goals>
-	      <goal>run</goal>
-	    </goals>
-	    <configuration>
-	      <tasks name="Rename">
-		<move filtering="true" todir="${project.build.directory}/doc/pod/NCD">
-		  <fileset dir="${project.build.directory}/doc/pod/NCD" />
-		  <mapper>
-		    <globmapper from="*.pm" to="*.pod" />
-		  </mapper>
-		</move>
-		<move filtering="true" todir="${project.build.directory}/doc/pod/NCM">
-		  <fileset dir="${project.build.directory}/doc/pod/NCM" />
-		  <mapper>
-		    <globmapper from="*.pm" to="*.pod" />
-		  </mapper>
-		</move>
-	      </tasks>
-	    </configuration>
-	  </execution>
-	</executions>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>rename-pod-sources</id>
+            <phase>process-sources</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <tasks name="Rename">
+                <move filtering="true" todir="${project.build.directory}/doc/pod/NCD">
+                  <fileset dir="${project.build.directory}/doc/pod/NCD"/>
+                  <mapper>
+                    <globmapper from="*.pm" to="*.pod"/>
+                  </mapper>
+                </move>
+                <move filtering="true" todir="${project.build.directory}/doc/pod/NCM">
+                  <fileset dir="${project.build.directory}/doc/pod/NCM"/>
+                  <mapper>
+                    <globmapper from="*.pm" to="*.pod"/>
+                  </mapper>
+                </move>
+              </tasks>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
-	<artifactId>maven-assembly-plugin</artifactId>
-	<extensions>true</extensions>
-	<executions>
-	  <execution>
-	    <id>tarballs</id>
-	    <configuration combine.self="override">
-	      <descriptors>
-		<descriptor>target/dependency/assemblies/bin.xml</descriptor>
-	      </descriptors>
-	    </configuration>
-	  </execution>
-	</executions>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <extensions>true</extensions>
+        <executions>
+          <execution>
+            <id>tarballs</id>
+            <configuration combine.self="override">
+              <descriptors>
+                <descriptor>target/dependency/assemblies/bin.xml</descriptor>
+              </descriptors>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
-
     </plugins>
   </build>
-
 </project>

--- a/src/main/config/bash_completion.d/ncm-ncd.sh
+++ b/src/main/config/bash_completion.d/ncm-ncd.sh
@@ -1,5 +1,3 @@
-#!/bin/bash
-#
 # ${license-info}
 # ${developer-info}
 # ${author-info}
@@ -18,8 +16,8 @@
 # component name.
 _ncm_ncd()
 {
-    local opts="--configure --verbose --debug --all --list --help"
-    local comps=`find /usr/lib/perl/NCM/Component -name '*.pm' -exec basename '{}' .pm ';'`
+    local opts="--all --allowbrokencomps --autodeps --cache_root --cfgfile --check-noquattor --chroot --configure --facility --forcelock --history --history-instances --ignore-errors-from-dependencies --ignorelock --include --list --logdir --multilog --noaction --nodeps --post-hook --post-hook-timeout --pre-hook --pre-hook-timeout --retries --skip --state --template-path --timeout --unconfigure --useprofile"
+    local comps=`find /usr/lib/perl/NCM/Component -maxdepth 1 -name '*.pm' -exec basename '{}' .pm ';'`
     COMPREPLY=()
     local cur="${COMP_WORDS[COMP_CWORD]}"
     case $cur in

--- a/src/test/perl/00-load.t
+++ b/src/test/perl/00-load.t
@@ -1,6 +1,13 @@
 # -*- mode: cperl -*-
 use strict;
 use warnings;
+
+BEGIN {
+    # Ignore the ncm namespace loaded by Test::Quattor
+    use Test::Quattor::Namespace;
+    $Test::Quattor::Namespace::ignore->{ncm} = 1;
+}
+
 use Test::More;
 use File::Find;
 use Test::Quattor;

--- a/src/test/perl/component-load.t
+++ b/src/test/perl/component-load.t
@@ -1,6 +1,12 @@
-# -*- mode: cperl -*-
 use strict;
 use warnings;
+
+BEGIN {
+    # Ignore the ncm namespace loaded by Test::Quattor
+    use Test::Quattor::Namespace;
+    $Test::Quattor::Namespace::ignore->{ncm} = 1;
+}
+
 use Test::More;
 use Test::Quattor qw(component-load);
 use NCD::ComponentProxy;
@@ -33,6 +39,8 @@ $mock->mock('error', sub (@) {
     diag("ERROR: $lasterror");
     $error++;
 });
+
+diag explain \@INC;
 
 # We'll be testing that some instantiations fail (non-existing
 # component paths or inactive components).  We just ignore these LC

--- a/src/test/perl/component-proxy-init.t
+++ b/src/test/perl/component-proxy-init.t
@@ -1,6 +1,13 @@
 # -*- mode: cperl -*-
 use strict;
 use warnings;
+
+BEGIN {
+    # Ignore the ncm namespace loaded by Test::Quattor
+    use Test::Quattor::Namespace;
+    $Test::Quattor::Namespace::ignore->{ncm} = 1;
+}
+
 use Test::More;
 use Test::Quattor qw(component-proxy-init);
 use NCD::ComponentProxy;

--- a/src/test/perl/component-proxy-list.t
+++ b/src/test/perl/component-proxy-list.t
@@ -1,5 +1,12 @@
 use strict;
 use warnings;
+
+BEGIN {
+    # Ignore the ncm namespace loaded by Test::Quattor
+    use Test::Quattor::Namespace;
+    $Test::Quattor::Namespace::ignore->{ncm} = 1;
+}
+
 use Test::More;
 use Test::Quattor qw(component-proxy-list);
 use NCD::ComponentProxyList;

--- a/src/test/perl/execute-config-components.t
+++ b/src/test/perl/execute-config-components.t
@@ -1,6 +1,13 @@
 # -*- mode: cperl -*-
 use strict;
 use warnings;
+
+BEGIN {
+    # Ignore the ncm namespace loaded by Test::Quattor
+    use Test::Quattor::Namespace;
+    $Test::Quattor::Namespace::ignore->{ncm} = 1;
+}
+
 use Test::More;
 use Test::Quattor qw(execute-config-components execute-config-deps);
 use NCD::ComponentProxyList;

--- a/src/test/perl/get-components.t
+++ b/src/test/perl/get-components.t
@@ -1,6 +1,13 @@
 # -*- mode: cperl -*-
 use strict;
 use warnings;
+
+BEGIN {
+    # Ignore the ncm namespace loaded by Test::Quattor
+    use Test::Quattor::Namespace;
+    $Test::Quattor::Namespace::ignore->{ncm} = 1;
+}
+
 use Test::More;
 use NCD::ComponentProxyList;
 use CAF::Object;

--- a/src/test/perl/hasfile.t
+++ b/src/test/perl/hasfile.t
@@ -1,6 +1,13 @@
 # -*- mode: cperl -*-
 use strict;
 use warnings;
+
+BEGIN {
+    # Ignore the ncm namespace loaded by Test::Quattor
+    use Test::Quattor::Namespace;
+    $Test::Quattor::Namespace::ignore->{ncm} = 1;
+}
+
 use Test::More;
 use CAF::Object;
 use LC::Exception;

--- a/src/test/perl/hooks.t
+++ b/src/test/perl/hooks.t
@@ -1,6 +1,13 @@
 # -*- mode: cperl -*-
 use strict;
 use warnings;
+
+BEGIN {
+    # Ignore the ncm namespace loaded by Test::Quattor
+    use Test::Quattor::Namespace;
+    $Test::Quattor::Namespace::ignore->{ncm} = 1;
+}
+
 use Test::More;
 use Test::Quattor qw(trivial);
 use NCD::ComponentProxyList;

--- a/src/test/perl/list-files.t
+++ b/src/test/perl/list-files.t
@@ -1,6 +1,13 @@
 # -*- mode: cperl -*-
 use strict;
 use warnings;
+
+BEGIN {
+    # Ignore the ncm namespace loaded by Test::Quattor
+    use Test::Quattor::Namespace;
+    $Test::Quattor::Namespace::ignore->{ncm} = 1;
+}
+
 use Test::More;
 use LC::Exception;
 use CAF::History qw($EVENTS $REF);

--- a/src/test/perl/runall.t
+++ b/src/test/perl/runall.t
@@ -1,6 +1,13 @@
 # -*- mode: cperl -*-
 use strict;
 use warnings;
+
+BEGIN {
+    # Ignore the ncm namespace loaded by Test::Quattor
+    use Test::Quattor::Namespace;
+    $Test::Quattor::Namespace::ignore->{ncm} = 1;
+}
+
 use Test::More;
 use Test::Quattor qw(runall-comps);
 use NCD::ComponentProxyList;

--- a/src/test/perl/skip-components.t
+++ b/src/test/perl/skip-components.t
@@ -1,6 +1,13 @@
 # -*- mode: cperl -*-
 use strict;
 use warnings;
+
+BEGIN {
+    # Ignore the ncm namespace loaded by Test::Quattor
+    use Test::Quattor::Namespace;
+    $Test::Quattor::Namespace::ignore->{ncm} = 1;
+}
+
 use Test::More;
 use Test::Quattor qw(runall-comps);
 use NCD::ComponentProxyList;

--- a/src/test/perl/sortcomponents.t
+++ b/src/test/perl/sortcomponents.t
@@ -1,6 +1,13 @@
 # -*- mode: cperl -*-
 use strict;
 use warnings;
+
+BEGIN {
+    # Ignore the ncm namespace loaded by Test::Quattor
+    use Test::Quattor::Namespace;
+    $Test::Quattor::Namespace::ignore->{ncm} = 1;
+}
+
 use Test::More;
 use Test::Quattor qw(cmplist);
 use NCD::ComponentProxyList;


### PR DESCRIPTION
Requires new buildtools with https://github.com/quattor/maven-tools/pull/77 in them