### PR TITLE
ncm-ncd: set default lock wait to 15 minutes

### DIFF
--- a/src/main/scripts/ncm-ncd
+++ b/src/main/scripts/ncm-ncd
@@ -89,7 +89,7 @@ sub app_options()
         {
             NAME    => 'retries=i',
             HELP    => 'number of retries if ncd is locked',
-            DEFAULT => 10
+            DEFAULT => 30
         },
 
         {


### PR DESCRIPTION
Fixes #69