### PR TITLE
Set the current active config as an attribute to the component

### DIFF
--- a/src/main/perl/Component.pm
+++ b/src/main/perl/Component.pm
@@ -226,6 +226,54 @@ sub set_active_config
     return $self->{ACTIVE_CONFIG};
 }
 
+=item get_tree
+
+Return C<EDG::WP4::CCM::Configuration->getTree> on the C<ACTIVE_CONFIG> attribute.
+
+All arguments are passed to C<getTree>.
+
+If no arguments are specified, the path passed to C<getTree> is
+the component prefix (using the C<prefix> method).
+
+If the path specified is not absolute, the path passed to C<getTree> is
+prefixed with the component prefix (using the C<prefix> method).
+
+Returns undef on failure, with C<fail> attribute set in case of an error.
+
+(Requires active configuration set).
+
+=cut
+
+sub get_tree
+{
+    my ($self, $path, @args) = @_;
+
+    if (! defined($path)) {
+        $path = $self->prefix();
+    } elsif ($path !~ m{^/}) {
+        my $prefix = $self->prefix();
+        $prefix =~ s{/*$}{}; # remove trailing /
+        $path = "$prefix/$path";
+    }
+
+    # Handle any previous errors on active config
+    delete $self->{ACTIVE_CONFIG}->{fail};
+    # Reset previous fail attribute
+    delete $self->{fail};
+    my $tree = $self->{ACTIVE_CONFIG}->getTree($path, @args);
+
+    if (defined($tree)) {
+        return $tree;
+    } else {
+        my $fail = $self->{ACTIVE_CONFIG}->{fail};
+        if (defined($fail)) {
+            return $self->fail($fail);
+        } else {
+            return;
+        }
+    }
+}
+
 =back
 
 =head1 Pure virtual methods

--- a/src/main/perl/Component.pm
+++ b/src/main/perl/Component.pm
@@ -274,6 +274,26 @@ sub get_tree
     }
 }
 
+=item get_fqdn
+
+Return the fqdn based on the current active config.
+
+This is either C<< /system/network/realhostname >> (if defined)
+or C<< </system/network/hostname>.</system/network/domainname> >>.
+
+(Requires active configuration set).
+
+=cut
+
+sub get_fqdn
+{
+    my ($self) = @_;
+
+    my $tree = $self->get_tree('/system/network');
+    # /system/network/hostname and /system/network/domainname are mandatory
+    return $tree->{realhostname} || "$tree->{hostname}.$tree->{domainname}";
+}
+
 =back
 
 =head1 Pure virtual methods

--- a/src/main/perl/Component.pm
+++ b/src/main/perl/Component.pm
@@ -209,6 +209,23 @@ sub event_report
     return \@idxs;
 }
 
+=item set_active_config
+
+Set C<config> as the C<ACTIVE_CONFIG> attribute.
+
+Returns the current active config.
+
+=cut
+
+sub set_active_config
+{
+    my ($self, $config) = @_;
+
+    $self->{ACTIVE_CONFIG} = $config;
+
+    return $self->{ACTIVE_CONFIG};
+}
+
 =back
 
 =head1 Pure virtual methods
@@ -252,28 +269,56 @@ sub Unconfigure
 
 =over
 
-=item _initialize($comp_name)
+=item _initialize
 
 object initialization (done via new)
+
+Arguments
+
+=over
+
+=item name
+
+Set the component name
+
+=item logger
+
+Set the logger instance (C<main::this_app> is used as default when undefined)
+
+=back
+
+Optional arguments
+
+=over
+
+=item config
+
+Set config as active config (using C<set_active_config> method).
+
+=back
 
 =cut
 
 sub _initialize
 {
-    my ($self, $name, $logger) = @_;
+    my ($self, $name, $logger, %opts) = @_;
 
     unless (defined $name) {
         throw_error('bad initialization (missing first "name" agument)');
         return;
     }
 
-    $self->{NAME}=$name;
-    $self->{ERRORS}=0;
-    $self->{WARNINGS}=0;
-    $self->{log} = defined $logger ? $logger: $this_app;
+    $self->{NAME} = $name;
+    $self->{ERRORS} = 0;
+    $self->{WARNINGS} = 0;
+    $self->{log} = defined $logger ? $logger : $this_app;
 
     # Keep LOGGER attribute for backwards compatibility
     $self->{LOGGER} = $self->{log};
+
+    if ($opts{config}) {
+        $self->set_active_config($opts{config});
+    }
 
     return SUCCESS;
 }

--- a/src/main/perl/ComponentProxy.pm
+++ b/src/main/perl/ComponentProxy.pm
@@ -555,7 +555,8 @@ sub _execute_dirty
     local $@;
     my $result;
     eval {
-        $result = $component->$method($self->{'CONFIG'});
+        $component->set_active_config($self->{CONFIG});
+        $result = $component->$method($self->{CONFIG});
     };
 
     my $formatter = $this_app->option('verbose') || $this_app->option('debug')

--- a/src/main/perl/ComponentProxy.pm
+++ b/src/main/perl/ComponentProxy.pm
@@ -195,6 +195,7 @@ object initialization (done via new)
 sub _initialize
 {
     my ($self, $name, $config, $run_from) = @_;
+
     $self->setup_reporter();
 
     if (!defined($name) || !defined($config)) {
@@ -610,7 +611,7 @@ sub _execute_dirty
             ERRORS => $component->get_errors()
         };
 
-        $self->info("configure on component $name executed, ",
+        $self->info("$method on component $name executed, ",
                     "$retval->{ERRORS} errors, ",
                     "$retval->{WARNINGS} warnings");
 

--- a/src/test/perl/NCM/Component/foo.pm
+++ b/src/test/perl/NCM/Component/foo.pm
@@ -30,6 +30,7 @@ sub Configure
     $self->error("foo Configure e3");
 
     $self->{_config} = $config;
+    $self->{_active_config} = $self->{ACTIVE_CONFIG};
 
     return 1;
 };

--- a/src/test/perl/NCM/Component/foo.pm
+++ b/src/test/perl/NCM/Component/foo.pm
@@ -29,6 +29,8 @@ sub Configure
     $self->error("foo Configure e2");
     $self->error("foo Configure e3");
 
+    $self->{_config} = $config;
+
     return 1;
 };
 

--- a/src/test/perl/component-execute.t
+++ b/src/test/perl/component-execute.t
@@ -113,6 +113,8 @@ isa_ok($component, 'NCM::Component::foo', '_load from Configure NCM::Component::
 is_deeply(\%ENV, \%ORIG_ENV, "_execute does not modify environment");
 
 is($component->{_config}, $cfg, "configuration instance passed during ComponentProxy init is passed to component foo Configure");
+is($component->{ACTIVE_CONFIG}, $cfg, "configuration instance set as ACTIVE_CONFIG by ComponentProxy");
+is($component->{_active_config}, $cfg, "configuration instance set as ACTIVE_CONFIG before Configure was called");
 
 # TODO: test noaction
 # TODO: test errors/warnings

--- a/src/test/perl/component-execute.t
+++ b/src/test/perl/component-execute.t
@@ -38,6 +38,7 @@ ok(! exists($ENV{TEST_COMPONENTPROXY}), 'ENV variable set by component foo does 
 
 my $mock = Test::MockModule->new('NCD::ComponentProxy');
 
+
 my $error = 0;
 my $lasterror;
 $mock->mock('error', sub (@) {
@@ -110,6 +111,8 @@ ok($history, "history reporting enabled");
 isa_ok($component, 'NCM::Component::foo', '_load from Configure NCM::Component::foo instance');
 
 is_deeply(\%ENV, \%ORIG_ENV, "_execute does not modify environment");
+
+is($component->{_config}, $cfg, "configuration instance passed during ComponentProxy init is passed to component foo Configure");
 
 # TODO: test noaction
 # TODO: test errors/warnings

--- a/src/test/perl/component.t
+++ b/src/test/perl/component.t
@@ -8,7 +8,6 @@ BEGIN {
 }
 
 use Test::More;
-
 use Test::Quattor qw(component1 component-fqdn);
 use Test::Quattor::Object;
 
@@ -44,6 +43,7 @@ is($cmp1->prefix(), "/software/components/component1", "prefix for component1");
 =cut
 
 my $cfg1 = get_config_for_profile('component1');
+
 ok(! defined($cmp1->{ACTIVE_CONFIG}), "no ACTIVE_CONFIG attribute set for component1 after init");
 my $ret = $cmp1->set_active_config($cfg1);
 is($ret, $cmp1->{ACTIVE_CONFIG}, "set_active_config sets and return ACTIVE_CONFIG attribute");
@@ -86,6 +86,20 @@ is($cmp2->{fail}, "*** path //invalid/path must be an absolute path: start '', r
 # should reset previous failure
 ok(!defined($cmp2->get_tree("/non/existing/path")), "non-existing path returns undef");
 ok(! defined($cmp2->{fail}), "non-existing path does not set fail attribute with get_tree");
+
+
+=head2 get_fqdn
+
+=cut
+
+ok(! defined($cmp2->get_tree("/system/network/realhostname")), "realhostname not set");
+is($cmp2->get_fqdn(), "short.example.com", "fqdn from hostname and domainname in absence of realhostname");
+
+my $cfg_fqdn = get_config_for_profile('component-fqdn');
+$cmp2->set_active_config($cfg_fqdn);
+my $realhostname = "something.else.example.org";
+is($cmp2->get_tree("/system/network/realhostname"), $realhostname, "realhostname set");
+is($cmp2->get_fqdn(), $realhostname, "fqdn from realhostname");
 
 
 done_testing;

--- a/src/test/perl/component.t
+++ b/src/test/perl/component.t
@@ -8,6 +8,7 @@ BEGIN {
 }
 
 use Test::More;
+
 use Test::Quattor qw(component1 component-fqdn);
 use Test::Quattor::Object;
 
@@ -28,7 +29,6 @@ use NCM::Component;
 
 is($NCM::Component::NoAction, 123, "NoAction set via this_app onload");
 
-
 my $obj = Test::Quattor::Object->new();
 
 =head1 test NCM::Component init
@@ -39,5 +39,22 @@ my $cmp1 = NCM::Component->new('component1', $obj);
 isa_ok($cmp1, 'NCM::Component', 'NCM::Component instance 1 created');
 is($cmp1->prefix(), "/software/components/component1", "prefix for component1");
 
+=head1 test set_active_config
+
+=cut
+
+my $cfg1 = get_config_for_profile('component1');
+ok(! defined($cmp1->{ACTIVE_CONFIG}), "no ACTIVE_CONFIG attribute set for component1 after init");
+my $ret = $cmp1->set_active_config($cfg1);
+is($ret, $cmp1->{ACTIVE_CONFIG}, "set_active_config sets and return ACTIVE_CONFIG attribute");
+is($ret, $cfg1, "set_active_config set active config to passed value");
+
+=head1 test NCM::Component init with active config
+
+=cut
+
+my $cmp2 = NCM::Component->new('component2', $obj, config => $cfg1);
+isa_ok($cmp2, 'NCM::Component', 'NCM::Component instance 2 created');
+is($cmp2->{ACTIVE_CONFIG}, $cfg1, "active config attribute set via init");
 
 done_testing;

--- a/src/test/resources/component1.pan
+++ b/src/test/resources/component1.pan
@@ -11,3 +11,4 @@ prefix "/software/components/component2";
 prefix "/system/network";
 "hostname" = "short";
 "domainname" = "example.com";
+

--- a/src/test/resources/component1.pan
+++ b/src/test/resources/component1.pan
@@ -11,4 +11,3 @@ prefix "/software/components/component2";
 prefix "/system/network";
 "hostname" = "short";
 "domainname" = "example.com";
-


### PR DESCRIPTION
Introduce the `ACTIVE_CONFIG` attribute, it is the same configuration instance that is passed to all method calls in `ComponentProxy` `_execute` method.
This allows to create a set of convenience methods in `NCM::Component`, that can be called without passing the config instance.
