### PR TITLE
NCM::Component: remove escape and unescape methods

### DIFF
--- a/src/main/perl/Component.pm
+++ b/src/main/perl/Component.pm
@@ -100,34 +100,6 @@ sub prefix
     return "/software/components/$self->{NAME}";
 }
 
-
-=item unescape
-
-Returns the unescaped version of the string provided as argument
-(using the C<<EDG::WP4::CCM::Path::unescape>> function).
-
-=cut
-
-sub unescape
-{
-    my ($self, $str) = @_;
-    return EDG::WP4::CCM::Path::unescape($str);
-}
-
-=item escape
-
-Returns the escaped version of the string provided as argument
-(using the C<<EDG::WP4::CCM::Path::escape>> function).
-
-=cut
-
-sub escape
-{
-    my ($self, $str) = @_;
-    return EDG::WP4::CCM::Path::escape($str);
-}
-
-
 =item get_warnings(): integer
 
 Returns the number of calls to 'warn' by the component.

--- a/src/test/perl/component.t
+++ b/src/test/perl/component.t
@@ -11,7 +11,6 @@ use Test::More;
 use Test::Quattor qw(component1 component-fqdn);
 use NCM::Component;
 use Test::Quattor::Object;
-use EDG::WP4::CCM::Path qw(escape unescape);
 
 my $obj = Test::Quattor::Object->new();
 
@@ -22,15 +21,6 @@ my $obj = Test::Quattor::Object->new();
 my $cmp1 = NCM::Component->new('component1', $obj);
 isa_ok($cmp1, 'NCM::Component', 'NCM::Component instance 1 created');
 is($cmp1->prefix(), "/software/components/component1", "prefix for component1");
-
-=head1 escape / unescape
-
-=cut
-
-my $to_escape = "/some/real/path, whitespace: others & !";
-my $escaped = escape($to_escape);
-is($escaped, $cmp1->escape($to_escape), "escape method works as expected");
-is($to_escape, $cmp1->unescape($escaped), "unescape method works as expected");
 
 
 done_testing;


### PR DESCRIPTION
Fixes https://github.com/quattor/configuration-modules-core/issues/958
Requires https://github.com/quattor/configuration-modules-core/pull/980 and https://github.com/quattor/aii/pull/233