### PR TITLE
ComponentProxy: disable uninitialized warnings while restoring ENV and SIG

### DIFF
--- a/src/main/perl/ComponentProxy.pm
+++ b/src/main/perl/ComponentProxy.pm
@@ -458,8 +458,11 @@ sub _execute
     my $res = $self->_execute_dirty($method);
 
     # restore original env and signals
+    # disable unitialized warnings (needed for old/EL5 perl)
+    no warnings qw(uninitialized);
     %ENV = %ENV_ORIG;
     %SIG = %SIG_ORIG;
+    use warnings qw(uninitialized);
 
     if (chdir($pwd)) {
         $self->debug(1, "Changed back to $pwd after executing component $name method $method");


### PR DESCRIPTION
In old perl (up to EL5), ENV and SIG are magic variables with their own warning handlers,
and you cannot assign an undef or empty string without triggering a warning.
In particular annoying to restore SIG, which is initalised as a hash with all possible
signals with undef value (and restoring those is one undef assignment per key, and thus one warning).

Unittests  on el5 fail due to these produced warnings.

Also fixes #75