### PR TITLE
CLI: disable log_world_readable and enable verbose_logfile by default

### DIFF
--- a/src/main/perl/CLI.pm
+++ b/src/main/perl/CLI.pm
@@ -59,7 +59,7 @@ sub app_options
 
         { NAME    => 'log_world_readable=i',
           HELP    => 'World readable logdir flag 1/0',
-          DEFAULT => 1 },
+          DEFAULT => 0 },
 
         { NAME    => 'verbose_logfile=i',
           HELP    => 'Report with verbose loglevel to the logfile',

--- a/src/main/perl/CLI.pm
+++ b/src/main/perl/CLI.pm
@@ -61,9 +61,9 @@ sub app_options
           HELP    => 'World readable logdir flag 1/0',
           DEFAULT => 1 },
 
-        { NAME    => 'verbose_logfile',
+        { NAME    => 'verbose_logfile=i',
           HELP    => 'Report with verbose loglevel to the logfile',
-          DEFAULT => 0 },
+          DEFAULT => 1 },
 
         { NAME    => 'logpid',
           HELP    => "Add process ID to the log messages (disabled by default)",

--- a/src/main/scripts/ncm-ncd.pod
+++ b/src/main/scripts/ncm-ncd.pod
@@ -84,7 +84,7 @@ option is not very useful if C<log_world_readable> is also true.
 =item --log_world_readable <0|1>
 
 World readable logdir flag (1/0). If true, the configured logdirectory
-will have its permissions set to 755. If false the permissions will be 700.
+will have its permissions set to 755. If false (the default) the permissions will be 700.
 
 These permissions will be set each time C<ncm-ncd> is run.
 

--- a/src/main/scripts/ncm-ncd.pod
+++ b/src/main/scripts/ncm-ncd.pod
@@ -100,7 +100,7 @@ Add process ID to the log messages (disabled by default).
 
 =item --verbose_logfile <0|1>
 
-Report with verbose loglevel to the logfile.
+Report with verbose loglevel to the logfile (default enabled)
 
 =item --retries <n>
 

--- a/src/test/perl/cli.t
+++ b/src/test/perl/cli.t
@@ -53,14 +53,14 @@ $mock_cli->mock('_get_uid', 0);
 $this_app = NCD::CLI->new(@baseopts,
                           '--log_group_readable', 'mygroup',
                           '--log_world_readable', 0,
-                          '--verbose_logfile', 1);
+                          '--verbose_logfile', 0);
 isa_ok($this_app, 'NCD::CLI', 'NCD::CLI created (for root user)');
 is_deeply($getperms, [qw(mygroup 0)], "GetPermissions called with log_group/world_readable options");
 is_deeply($Test::Quattor::caf_path->{directory},
           [[['target'],{group => 20, mode => 493}]],
           "CAF::Path directory called on logdir");
 # ugly, but no other way
-is($this_app->_rep_setup()->{$VERBOSE_LOGFILE}, 1, "verbose_logfile is enabled");
+is($this_app->_rep_setup()->{$VERBOSE_LOGFILE}, 0, "verbose_logfile is disabled");
 
 my @allopts = map {$_->{NAME}} @{$this_app->app_options()};
 is(scalar @allopts, 35, "expected number of options");
@@ -76,7 +76,7 @@ $this_app = NCD::CLI->new(@baseopts, '--list');
 isa_ok($this_app, 'NCD::CLI', 'NCD::CLI created (for root user)');
 # Change previous test when changing the default (so the opposite is tested)
 is_deeply($getperms, [undef, 1], "GetPermissions called with default log_group/world_readable options (undef/0)");
-is($this_app->_rep_setup()->{$VERBOSE_LOGFILE}, 0, "verbose_logfile is disabled by default");
+is($this_app->_rep_setup()->{$VERBOSE_LOGFILE}, 1, "verbose_logfile is enabled by default");
 
 eval {$this_app->main($ec);};
 like($@, qr{^exit 0 at}, "exit called on --list with code 0");

--- a/src/test/perl/cli.t
+++ b/src/test/perl/cli.t
@@ -52,10 +52,10 @@ CAF::Reporter::init_reporter();
 $mock_cli->mock('_get_uid', 0);
 $this_app = NCD::CLI->new(@baseopts,
                           '--log_group_readable', 'mygroup',
-                          '--log_world_readable', 0,
+                          '--log_world_readable', 1,
                           '--verbose_logfile', 0);
 isa_ok($this_app, 'NCD::CLI', 'NCD::CLI created (for root user)');
-is_deeply($getperms, [qw(mygroup 0)], "GetPermissions called with log_group/world_readable options");
+is_deeply($getperms, [qw(mygroup 1)], "GetPermissions called with log_group/world_readable options");
 is_deeply($Test::Quattor::caf_path->{directory},
           [[['target'],{group => 20, mode => 493}]],
           "CAF::Path directory called on logdir");
@@ -75,7 +75,7 @@ CAF::Reporter::init_reporter();
 $this_app = NCD::CLI->new(@baseopts, '--list');
 isa_ok($this_app, 'NCD::CLI', 'NCD::CLI created (for root user)');
 # Change previous test when changing the default (so the opposite is tested)
-is_deeply($getperms, [undef, 1], "GetPermissions called with default log_group/world_readable options (undef/0)");
+is_deeply($getperms, [undef, 0], "GetPermissions called with default log_group/world_readable options (undef/0)");
 is($this_app->_rep_setup()->{$VERBOSE_LOGFILE}, 1, "verbose_logfile is enabled by default");
 
 eval {$this_app->main($ec);};

--- a/src/test/perl/list-files.t
+++ b/src/test/perl/list-files.t
@@ -19,7 +19,7 @@ use Test::MockModule;
 our $this_app;
 
 BEGIN {
-    $this_app = CAF::Application->new('app');
+    $this_app = CAF::Application->new('app', '--debug', 5);
     $this_app->{CONFIG}->define("noaction");
     $this_app->{CONFIG}->set('noaction', 1);
 }


### PR DESCRIPTION
Fixes #93 
Fixes #94 

To keep old behaviour after these defaults of 16.10
https://github.com/quattor/configuration-modules-core/pull/948
```pan
include 'metaconfig/ncm-ncd/config';
prefix "/software/components/metaconfig/services/{/etc/ncm-ncd.conf}/contents";
"log_world_readable" = true;
"verbose_logfile" = false;
```