### PR TITLE
ncm-ncd: modified event reporting under NoAction=1 with new FileWriter

### DIFF
--- a/src/test/perl/list-files.t
+++ b/src/test/perl/list-files.t
@@ -53,7 +53,8 @@ diag explain $this_app->{HISTORY}->{EVENTS};
 my $closeev = $this_app->{HISTORY}->{EVENTS}->[1];
 
 is($closeev->{REF}, 'CAF::FileWriter', 'event added by FileWriter');
-is($closeev->{modified}, 1, 'event of modified FileWriter');
+is($closeev->{changed}, 1, 'event of content changed FileWriter (noaction=1)');
+is($closeev->{modified}, 0, 'event of unmodified FileWriter (noaction=1)');
 
 is($closeev->{component}, 'foo', 'Component name added to metadata');
 is($closeev->{component_module}, 'NCM::Component', 'Component module added to metadata');
@@ -78,32 +79,47 @@ $fh = undef;
 diag explain $this_app->{$HISTORY}->{$EVENTS};
 
 
-$closeev = $this_app->{$HISTORY}->{$EVENTS}->[3];
+my $closeev2 = $this_app->{$HISTORY}->{$EVENTS}->[3];
 
-is($closeev->{$REF}, 'CAF::FileWriter', 'event added by FileWriter by cmp2');
-is($closeev->{modified}, 1, 'event of modified FileWriter by cmp2');
+is($closeev2->{$REF}, 'CAF::FileWriter', 'event added by FileWriter by cmp2');
+is($closeev2->{changed}, 1, 'event of content changed FileWriter by cmp2 (noaction=1)');
+is($closeev2->{modified}, 0, 'event of unmodified FileWriter by cmp2 (noaction=1)');
 
-is($closeev->{component}, 'bar', 'Component name bar by cmp2');
-is($closeev->{component_module}, 'NCM::Component', 'Component module by cmp2');
+is($closeev2->{component}, 'bar', 'Component name bar by cmp2');
+is($closeev2->{component_module}, 'NCM::Component', 'Component module by cmp2');
 
+# noaction=1, so nothing really modified
 
-# test reporting by cmp
 @info_msgs = ();
 my $idx1 = $cmp->event_report();
-is_deeply(\@info_msgs,
-          ["EVENT: foo modified file target/test/some/file"],
-          "cmp reports 1 modified file");
-is_deeply($idx1, [1], "reported indices by cmp");
+is_deeply(\@info_msgs, [], "Nothing reported with cmp (noaction=1)");
 
 @info_msgs = ();
 my $idx2 = $cmp2->event_report();
+is_deeply(\@info_msgs, [], "Nothing reported with cmp2 (noaction=1)");
+
+# Fake noaction=0 in event history
+$closeev->{modified} = 1;
+$closeev2->{modified} = 1;
+$this_app->{$HISTORY}->{$EVENTS}->[5]->{modified} = 1;
+
+# test reporting by cmp
+@info_msgs = ();
+$idx1 = $cmp->event_report();
+is_deeply(\@info_msgs,
+          ["EVENT: foo modified file target/test/some/file"],
+          "cmp reports 1 modified file (faked noaction=0)");
+is_deeply($idx1, [1], "reported indices by cmp (faked noaction=0)");
+
+@info_msgs = ();
+$idx2 = $cmp2->event_report();
 diag explain \@info_msgs;
 diag explain $idx2;
 is_deeply(\@info_msgs, [
     "EVENT: bar modified file target/test/some/file",
     "EVENT: bar modified file target/test/some/file2",
-], "cmp2 reports 1 modified file");
-is_deeply($idx2, [3, 5], "reported indices by cmp2");
+], "cmp2 reports 1 modified file (faked noaction=0)");
+is_deeply($idx2, [3, 5], "reported indices by cmp2 (faked noaction=0)");
 
 
 done_testing();


### PR DESCRIPTION
Requires https://github.com/quattor/CAF/pull/202

incompatibility wrt the way FileWriter events are reported under NoAction using new filewriter