### PR TITLE
Fix garbled log message with double 'ing'

### DIFF
--- a/src/main/perl/CLI.pm
+++ b/src/main/perl/CLI.pm
@@ -567,11 +567,11 @@ sub report_exit
     $methodmsg =~ s/e$/ing/;
 
     if ($ret->{ERRORS}) {
-        $self->info("Errors while ${methodmsg}ing ", mk_msg($ret->{ERR_COMPS}, $ret->{CLIST}));
+        $self->info("Errors while ${methodmsg} ", mk_msg($ret->{ERR_COMPS}, $ret->{CLIST}));
     }
 
     if ($ret->{WARNINGS}) {
-        $self->info("Warnings while ${methodmsg}ing ", mk_msg($ret->{WARN_COMPS}, $ret->{CLIST}));
+        $self->info("Warnings while ${methodmsg} ", mk_msg($ret->{WARN_COMPS}, $ret->{CLIST}));
     }
 
     $self->$report_method($ret->{'ERRORS'}, ' errors, ', $ret->{'WARNINGS'}, ' warnings ', "executing $action");


### PR DESCRIPTION
`$methodmsg` is already modified to add the 'ing', doing it twice just looks odd.

Fixes #111.