### PR TITLE
rework chdir handling use mktemp instead of '/tmp'

### DIFF
--- a/src/main/perl/CLI.pm
+++ b/src/main/perl/CLI.pm
@@ -15,7 +15,6 @@ use Readonly;
 Readonly my $QUATTOR_LOCKDIR => '/var/lock/quattor';
 Readonly my $NCD_LOGDIR => '/var/log/ncm';
 Readonly my $NCD_CONFIGFILE => '/etc/ncm-ncd.conf';
-Readonly my $NCD_CHDIR => '/tmp';
 
 =head1 NAME NCD::CLI
 
@@ -504,10 +503,6 @@ sub action
     if ($self->option("chroot")) {
         chroot($self->option("chroot")) or die "Unable to chroot to ", $self->option("chroot");
     }
-
-    if(! chdir($NCD_CHDIR)) {
-        $self->warn("Failed to change to directory $NCD_CHDIR");
-    };
 
     my $ret = $compList->$method(@args);
 

--- a/src/main/perl/ComponentProxy.pm
+++ b/src/main/perl/ComponentProxy.pm
@@ -13,6 +13,7 @@ use Cwd qw(getcwd);
 use Module::Load;
 
 use File::Path;
+use File::Temp;
 
 our $this_app;
 *this_app = \$main::this_app;
@@ -21,7 +22,7 @@ my $ec = LC::Exception::Context->new->will_store_all;
 
 use Readonly;
 Readonly my $COMPONENTS_PROFILE_PATH => '/software/components';
-Readonly my $RUN_FROM => '/tmp';
+Readonly my $RUN_FROM => File::Temp->newdir('/tmp/ncd-components-XXXXXXXX');
 
 Readonly my $COMPONENT_BASE => "/usr/lib/perl/NCM/Component";
 # Methods called during _execute

--- a/src/main/perl/ComponentProxy.pm
+++ b/src/main/perl/ComponentProxy.pm
@@ -535,11 +535,12 @@ sub _execute_dirty
         }
     }
 
-    # run from /tmp
+    # run from tmpdir
     if (chdir($RUN_FROM)) {
         $self->debug(1, "Changed to $RUN_FROM before executing component $name method $method");
     } else {
-        $self->warn("Fail to change to $RUN_FROM before executing component $name method $method");
+        $self->error("Fail to change to $RUN_FROM before executing component $name method $method");
+        $self->finish(-1);
     };
 
     # USR1 reports current active component / method


### PR DESCRIPTION
There are multiple changes here. It displays my current understanding of how these modules do chdir.

The current behavior is:

1. NCD::CLI enters `/tmp`
2. NCD::ComponentProxy enters `/tmp`
3. a component is executed
4. NCD::ComponentProxy restores to `/tmp` (which NCD::CLI set up)
5. then back to step 2.

New proposed behavior after this change:

Instead of `/tmp` a `/tmp/ncd-components-XXXXXXXX` (x's replaced with random alphanumerics) is used. (This is good because `/tmp` is a hostile environment being a world-writable directory.)
Step 1. removed. Step 4. kept because we need to leave the tempdir to let the module to automatically clean it up.

If a module changes the current directory during its execution Step 2. still changes back to the previous.

1. NCD::ComponentProxy enters `/tmp/ncd-components-XXXXXXXX`.
2. a component is executed
3. NCD::ComponentProxy restores to whatever the ncm-ncd was invoked from
4. then back to step 1.