### PR TITLE
Add graph based report of component dependencies

### DIFF
--- a/src/main/config/bash_completion.d/ncm-ncd.sh
+++ b/src/main/config/bash_completion.d/ncm-ncd.sh
@@ -12,7 +12,7 @@ unset _ncm_ncd_ccm_bashcompletion_fn
 
 _quattor_ncm_ncd_default_options=(debug help quiet verbose version)
 
-_quattor_ncm_ncd_options=(all allowbrokencomps autodeps cache_root cfgfile check-noquattor chroot configure facility force-quattor forcelock history history-instances ignore-errors-from-dependencies ignorelock include list log_group_readable log_world_readable logdir logpid multilog noaction nodeps post-hook post-hook-timeout pre-hook pre-hook-timeout report report-format retries skip state timeout unconfigure useprofile verbose_logfile)
+_quattor_ncm_ncd_options=(all allowbrokencomps autodeps cache_root cfgfile check-noquattor chroot configure facility force-quattor forcelock graph history history-instances ignore-errors-from-dependencies ignorelock include list log_group_readable log_world_readable logdir logpid multilog noaction nodeps post-hook post-hook-timeout pre-hook pre-hook-timeout report report-format retries skip state timeout unconfigure useprofile verbose_logfile)
 
 # boolean options which are true by default
 _quattor_ncm_ncd_no_options=(no-autodeps no-check-noquattor)

--- a/src/main/perl/CLI.pm
+++ b/src/main/perl/CLI.pm
@@ -44,6 +44,9 @@ sub app_options
         { NAME    => 'list',
           HELP    => 'list existing components and exit' },
 
+        { NAME    => 'graph',
+          HELP    => 'output component dependencies in Graphviz DOT format and exit' },
+
         { NAME    => 'configure',
           HELP    => 'run the configure method on the components (passed as arguments, not values for this option)' },
 
@@ -398,7 +401,7 @@ sub check_options
     $self->info('Dry run, no changes will be performed (--noaction flag set)')
         if ($self->option('noaction'));
 
-    my @exclusive_required = qw(configure unconfigure list report);
+    my @exclusive_required = qw(configure unconfigure list graph report);
     my @used;
     foreach my $option (@exclusive_required) {
         push(@used, $option) if $self->option($option);
@@ -567,7 +570,7 @@ sub action
             $self->error("Failed to report state");
             $self->finish(-1);
         }
-    } elsif ($self->option('list')) {
+    } elsif ($self->option('list') || $self->option('graph')) {
         # Just do the list here
         my $compList = NCD::ComponentProxyList->new($self->getCCMConfig());
         unless (defined $compList) {
@@ -575,7 +578,13 @@ sub action
             $self->error("cannot get component(s)");
             $self->finish(-1);
         }
-        $compList->reportComponents();
+        if ($self->option('list')) {
+            $compList->reportComponents();
+        } elsif ($self->option('graph')) {
+            $compList->reportComponentsGraph();
+        } else {
+            $self->finish(-1);
+        };
         $self->finish(0);
     } elsif ($self->option('unconfigure')) {
         # Sanity check the components passed to unconfigure

--- a/src/test/perl/cli.t
+++ b/src/test/perl/cli.t
@@ -65,7 +65,7 @@ is_deeply($Test::Quattor::caf_path->{directory},
 is($this_app->_rep_setup()->{$VERBOSE_LOGFILE}, 0, "verbose_logfile is disabled");
 
 my @allopts = map {$_->{NAME}} @{$this_app->app_options()};
-is(scalar @allopts, 37, "expected number of options");
+is(scalar @allopts, 38, "expected number of options");
 
 my $reportcomps;
 $mock_cpl->mock('reportComponents', sub {my $self = shift; $reportcomps = [map {$_->name()} @{$self->{CLIST}}];});

--- a/src/test/perl/tabcompletion.t
+++ b/src/test/perl/tabcompletion.t
@@ -163,7 +163,7 @@ is_deeply(bash_split_opts('_quattor_ncm_ncd_default_options'),
           "_quattor_ncm_ncd_default_options");
 
 Readonly::Array my @OPTIONS => qw(all allowbrokencomps autodeps cache_root cfgfile
-check-noquattor chroot configure facility force-quattor forcelock history history-instances
+check-noquattor chroot configure facility force-quattor forcelock graph history history-instances
 ignore-errors-from-dependencies ignorelock include list
 log_group_readable log_world_readable logdir logpid multilog noaction nodeps
 post-hook post-hook-timeout pre-hook pre-hook-timeout report report-format retries


### PR DESCRIPTION
Essentially `--list` in graph form.
This also highlights the sorted execution order for all components.

For example:
![comps](https://user-images.githubusercontent.com/323309/120471802-14223500-c39d-11eb-887c-c5a966b29a62.png)