### PR TITLE
Add an explicit dependency on the Perl metapackage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,7 @@
             </mappings>
             <requires>
               <require>logrotate</require>
+              <require>perl</require>
             </requires>
           </configuration>
         </plugin>


### PR DESCRIPTION
In EL9 this solves the issue of missing modules required by components.

According to the packaging guidelines, we should have a dependency on `perl-interpreter` here, but we have assumptions on more modules being present than are provided by just the base interpreter package.